### PR TITLE
Add first pass of standard_implementation template

### DIFF
--- a/standard_implementation/document.adoc
+++ b/standard_implementation/document.adoc
@@ -23,6 +23,8 @@
 :pdf-uri: ./document.pdf
 :xml-uri: ./document.xml
 :doc-uri: ./document.doc
+:imagesdir: images
+:stem:
 
 
 // Clauses

--- a/standard_implementation/document.adoc
+++ b/standard_implementation/document.adoc
@@ -1,29 +1,57 @@
-= Implementation Standard for OGC (IS) - Add title text
+= Implementation Standard for OGC (IS); Add title text
+:comment: ### Document type; mandatory. Visit: https://www.metanorma.com/author/ogc/authoring/ for permitted types
 :doctype: standard
+:comment: ### Document subtype; optional. Visit: https://www.metanorma.com/author/ogc/authoring/ for permitted types
 :docsubtype: implementation
-:edition: 1.0
+:comment: ### Version number; optional. Dot-delimited, preferably with this structure <version number>.<minor version number>.<patch version number>
+:edition: 1.0.0
+:comment: ### Language of the document; mandatory. Specified in two-letter code: "en" for English, "fr" for French
 :language: en
+:comment: ### Document status/stage; mandatory. Visit: https://www.metanorma.com/author/ogc/authoring/ for permitted types
 :status: approved
+:comment: ### Relevant committee; mandatory. The permitted types are: technical, planning, and strategic-member-advisory
 :committee: technical
-:docnumber: YY-999r9
+:comment: ### Internal reference number; mandatory
+:docnumber: 17-069r3
+:comment: ### Date on which the standard was updated; mandatory
 :received-date: 2019-07-11
+:comment: ### Date on which the standard was approved by the issuing authority; mandatory
 :issued-date: 2019-09-09
+:comment: ### Date on which the standard was published; mandatory
 :published-date: 2019-10-14
-:external-id: http://www.opengis.net/doc/{doc-type}/{standard}/{m.n}
-:fullname: Editor One
-:fullname_2: Editor Two
+:comment: ### External link referencing the document; optional. If not provided, a default value is created following this structure: "http://www.opengis.net/doc/{abbrevation of doctype}/{abbrev}/{version}", 
+:external-id: http://www.opengis.net/doc/IS/ogcapi-features-1/1.0
+:comment: ### Author one
+:fullname: Clemens Portele
+:comment: ### Author two
+:fullname_2: Panagiotis (Peter) A. Vretanos
+:comment: ### Author three
+:fullname_2:  Charles Heazel
+:comment: ### Role of the authors; mandatory
 :role: editor
-:keywords: keyword one, keyword two, etc
-:submitting-organizations: Organization One; Organization Two; Organization three
+:comment: ### Comma delimited keywords; mandatory
+:keywords: ogcdoc, OGC document, OGC API, ISO, ISO/TC 211, geographic information, Geospatial API, Web Feature Service, WFS, feature, features, property, geographic information, spatial data, spatial things, dataset, distribution, API, OpenAPI, GeoJSON, GML, HTML, schema.org
+:comment: ### Semicolon-delimited list of the submitting organizations; mandatory
+:submitting-organizations: CubeWerx Inc; Heazeltech LLC; Hexagon; interactive instruments GmbH; Ordnance Survey; Planet Labs; US Army Geospatial Center (AGC)
+:comment: ### Name of the AsciiDoc file; mandatory
 :docfile: document.adoc
+:comment: ### Metanorma flavor; mandatory
 :mn-document-class: ogc
+:comment: ### Desired output formats; mandatory
 :mn-output-extensions: xml,html,doc,pdf,rxl
+:comment: ### Enable local relaton cache for quick inclusion of prefetched references; optional. For further information, visit: https://www.metanorma.com/author/ref/document-attributes/#caches, https://www.metanorma.com/author/topics/building/reference-lookup/#lookup-result-caching
 :local-cache-only:
+:comment: ### Encode all images in HTML output as inline data-URIs; optional
 :data-uri-image:
+:comment: ### URI to which the PDF version of this standard is published; optional
 :pdf-uri: ./document.pdf
+:comment: ### URI to which the XML version of this standard is published; optional
 :xml-uri: ./document.xml
+:comment: ### URI to which the DOC version of this standard is published; optional
 :doc-uri: ./document.doc
+:comment: ### Directory name used as prefix for the location of image files; optional
 :imagesdir: images
+:comment: ### Enable rendering of AsciiMath, MathML, and LaTeX ("latexmath" needs to be indicated in the code to use LaTeX, or set ":stem: latexmath" to interpret by default); optional
 :stem:
 
 

--- a/standard_implementation/document.adoc
+++ b/standard_implementation/document.adoc
@@ -1,0 +1,47 @@
+= Implementation Standard for OGC (IS) - Add title text
+:doctype: standard
+:docsubtype: implementation
+:edition: 1.0
+:language: en
+:status: approved
+:committee: technical
+:docnumber: YY-999r9
+:received-date: 2019-07-11
+:issued-date: 2019-09-09
+:published-date: 2019-10-14
+:external-id: http://www.opengis.net/doc/{doc-type}/{standard}/{m.n}
+:fullname: Editor One
+:fullname_2: Editor Two
+:role: editor
+:keywords: keyword one, keyword two, etc
+:submitting-organizations: Organization One; Organization Two; Organization three
+:docfile: document.adoc
+:mn-document-class: ogc
+:mn-output-extensions: xml,html,doc,pdf,rxl
+:local-cache-only:
+:data-uri-image:
+:pdf-uri: ./document.pdf
+:xml-uri: ./document.xml
+:doc-uri: ./document.doc
+
+
+// Clauses
+include::sections/00-preface.adoc[]
+include::sections/01-scope.adoc[]
+include::sections/02-conformance.adoc[]
+include::sections/03-references.adoc[]
+include::sections/04-terms_and_definitions.adoc[]
+include::sections/05-conventions.adoc[]
+include::sections/06-requirement_classes.adoc[]
+include::sections/07-media-types.adoc[]
+
+// Annexes
+include::sections/aa-annexA.adoc[]
+include::sections/ab-annexB.adoc[]
+
+// Revision history
+include::sections/ah-history.adoc[]
+
+// Bibliography
+include::sections/az-bibliography.adoc[]
+

--- a/standard_implementation/sections/00-preface.adoc
+++ b/standard_implementation/sections/00-preface.adoc
@@ -1,0 +1,82 @@
+
+.Preface
+
+<Insert Preface text here>
+
+[NOTE]
+====
+Give OGC specific commentary: describe the technical content, reason for document, history of the document and precursors, and plans for future work.
+
+There are two ways to specify the Preface: "simple clause" or "full clasuse"
+
+If the Preface does not contain subclauses, it is considered a simple preface clause. This one is entered as text after the `.Preface` label and must be placed between the AsciiDoc document attributes and the first AsciiDoc section title. It should not be give a section title of its own.
+
+If the Preface contains subclauses, it needs to be encoded as a full preface clause. This one is recognized as a full Metanorma AsciiDoc section with te title "Preface", i.e. `== Preface`. (Simple preface content can also be encoded like full preface.) 
+====
+
+////
+NOTE: Uncomment OGC Declaration section if necessary
+
+*OGC Declaration*
+
+Attention is drawn to the possibility that some of the elements of this document may be the subject of patent rights. The Open Geospatial Consortium Inc. shall not be held responsible for identifying any or all such patent rights.
+
+Recipients of this document are requested to submit, with their comments, notification of any relevant patent claims or other intellectual property rights of which they may be aware that might be infringed by any implementation of the standard set forth in this document, and to provide supporting documentation.
+////
+
+////
+NOTE: Uncomment ISO section if necessary
+
+*ISO Declaration*
+
+ISO (the International Organization for Standardization) is a worldwide federation of national standards bodies (ISO member bodies). The work of preparing International Standards is normally carried out through ISO technical committees. Each member body interested in a subject for which a technical committee has been established has the right to be represented on that committee. International organizations, governmental and non-governmental, in liaison with ISO, also take part in the work. ISO collaborates closely with the International Electrotechnical Commission (IEC) on all matters of electrotechnical standardization.
+
+International Standards are drafted in accordance with the rules given in the ISO/IEC Directives, Part 2.
+
+The main task of technical committees is to prepare International Standards. Draft International Standards adopted by the technical committees are circulated to the member bodies for voting. Publication as an International Standard requires approval by at least 75 % of the member bodies casting a vote.
+
+Attention is drawn to the possibility that some of the elements of this document may be the subject of patent rights. ISO shall not be held responsible for identifying any or all such patent rights.
+////
+
+[abstract]
+== Abstract
+
+<Insert Abstract here>
+
+[NOTE]
+====
+The abstract is recognized as the first clause with an `abstract` style attribute.
+====
+
+
+[.preface]
+== Submitters
+
+[NOTE]
+====
+"Submitters" are entered using a table, contained in a section with the title `Submitters`. Such table must include `%unnumbered` style attribute in order to remove unwanted numbering tag.
+====
+
+
+[example]
+====
+|===
+|Name |Affiliation |OGC member
+
+|Steve Liang | University of Calgary, Canada / SensorUp Inc. | Yes
+|===
+====
+
+
+[example]
+====
+All questions regarding this submission should be directed to the editor or the submitters:
+
+|===
+|Name |Affiliation
+
+|Boyan Brodaric |GSC
+|Alexander Kmoch |U Salzburg
+|===
+====
+

--- a/standard_implementation/sections/01-scope.adoc
+++ b/standard_implementation/sections/01-scope.adoc
@@ -1,0 +1,9 @@
+
+== Scope
+
+<Insert Scope text here.>
+
+[NOTE]
+====
+Give the subject of the document and the aspects of that scope covered by the document.
+====

--- a/standard_implementation/sections/02-conformance.adoc
+++ b/standard_implementation/sections/02-conformance.adoc
@@ -1,0 +1,17 @@
+
+== Conformance
+This standard defines XXXX.
+
+Requirements for N standardization target types are considered:
+
+* AAAA
+* BBBB
+
+Conformance with this standard shall be checked using all the relevant tests specified in Annex A (normative) of this document. The framework, concepts, and methodology for testing, and the criteria to be achieved to claim conformance are specified in the OGC Compliance Testing Policies and Procedures and the OGC Compliance Testing web site.
+
+In order to conform to this OGC® interface standard, a software implementation shall choose to implement:
+
+* Any one of the conformance levels specified in Annex A (normative).
+* Any one of the Distributed Computing Platform profiles specified in Annexes TBD through TBD (normative).
+
+All requirements-classes and conformance-classes described in this document are owned by the standard(s) identified.

--- a/standard_implementation/sections/03-references.adoc
+++ b/standard_implementation/sections/03-references.adoc
@@ -1,0 +1,30 @@
+
+[bibliography]
+== References
+
+The following normative documents contain provisions that, through reference in this text, constitute provisions of this document. For dated references, subsequent amendments to, or revisions of, any of these publications do not apply. For undated references, the latest edition of the normative document referred to applies.
+
+[NOTE]
+====
+Insert References here. If there are no references, leave this section empty.
+
+References are to follow the Springer LNCS style, with the exception that optional information may be appended to references: DOIs are added after the date and web resource references may include an access date at the end of the reference in parentheses. See examples from Springer and OGC below.
+====
+
+* [[[openapi,Open API Initiative]]], Open API Initiative: *OpenAPI Specification 3.0.2*, 2018 https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md
+
+* [[[rfc2616,RFC 2616]]], Fielding, R., Gettys, J., Mogul, J., Frystyk, H., Masinter, L., Leach, P., Berners-Lee, T.: IETF RFC 2616, *HTTP/1.1*, 1999 http://tools.ietf.org/rfc/rfc2616.txt
+
+* [[[rfc2818,RFC 2818]]], Rescorla, E.: IETF RFC 2818, *HTTP Over TLS*, 2000 http://tools.ietf.org/rfc/rfc2818.txt
+
+* [[[rfc3339,RFC 3339]]], Klyne, G., Newman, C.: IETF RFC 3339, *Date and Time on the Internet: Timestamps*, 2002 http://tools.ietf.org/rfc/rfc3339.txt
+
+* [[[rfc8288,RFC 8288]]], Nottingham, M.: IETF RFC 8288, *Web Linking*, 2017 http://tools.ietf.org/rfc/rfc8288.txt
+
+* [[[gmlsf,GMLSF]]], van den Brink, L., Portele, C., Vretanos, P.: OGC 10-100r3, *Geography Markup Language (GML) Simple Features Profile*, 2012 http://portal.opengeospatial.org/files/?artifact_id=42729
+
+* [[[rfc7946,RFC 7946]]], Butler, H., Daly, M., Doyle, A., Gillies, S., Hagen, S., Schaub, T.: IETF RFC 7946, *The GeoJSON Format*, 2016 https://tools.ietf.org/rfc/rfc7946.txt
+
+* [[[html5, HTML5]]], W3C: *HTML5*, W3C Recommendation, 2019 http://www.w3.org/TR/html5/
+
+* [[[schema,Schema.org]]], *Schema.org:* http://schema.org/docs/schemas.html

--- a/standard_implementation/sections/04-terms_and_definitions.adoc
+++ b/standard_implementation/sections/04-terms_and_definitions.adoc
@@ -1,0 +1,17 @@
+
+== Terms and Definitions
+
+This document uses the terms defined in Sub-clause 5.3 of [OGC 06-121r9], which is based on the ISO/IEC Directives, Part 2, Rules for the structure and drafting of International Standards. In particular, the word "`shall`" (not "`must`") is the verb form used to indicate a requirement to be strictly followed to conform to this standard.
+
+=== example term
+
+term used for exemplary purposes
+
+[.source]
+<<ISO19101-1>>
+
+NOTE: An example note.
+
+[example]
+Here's an example of an example term.
+

--- a/standard_implementation/sections/05-conventions.adoc
+++ b/standard_implementation/sections/05-conventions.adoc
@@ -1,0 +1,21 @@
+
+== Conventions
+
+[NOTE]
+====
+This section provides details and examples for any conventions used in the document. Examples of conventions are symbols, abbreviations, use of XML schema, or special notes regarding how to read the document.
+====
+
+
+=== Identifiers
+
+The normative provisions in this standard are denoted by the URI 
+
+`http://www.opengis.net/spec/{standard}/{m.n}`
+
+All requirements and conformance tests that appear in this document are denoted by partial URIs which are relative to this base.
+
+
+=== Other conventions
+
+<Place any other convention needed with its corresponding title.>

--- a/standard_implementation/sections/06-overview.adoc
+++ b/standard_implementation/sections/06-overview.adoc
@@ -1,0 +1,68 @@
+
+== Overview
+
+[NOTE]
+====
+Place revelevant considerations about design implementation here.
+====
+
+////
+=== Design considerations
+
+While this is the first version of the OGC API Features series, the fine-grained access to features over the Web has been supported by the <<wfs20,OGC Web Feature Service (WFS)>> standard (in ISO: <<iso19142,ISO 19142>>) and many implementations of that standard for many years. WFS uses a Remote-Procedure-Call-over-HTTP architectural style using XML for any payloads. When the WFS standard was originally designed in the late 1990s and early 2000s this was the state-of-the-art.
+
+OGC API Features supports similar capabilities, but using a modernized approach that follows the current Web architecture and in particular the <<spatial_data_wbp,W3C/OGC best practices for sharing Spatial Data on the Web>> as well as the <<dwbp,W3C best practices for sharing Data on the Web>>.
+
+Beside the general alignment with the architecture of the Web (e.g., consistency with HTTP/HTTPS, hypermedia controls), another goal for OGC API Features is modularization. This goal has several facets, as described below.
+
+* Clear separation between core requirements and more advanced capabilities. This document specifies the core requirements that are relevant for almost everyone who wants to share or use feature data on a fine-grained level. Additional capabilities that several communities are using today will be specified as extensions in additional parts of the OGC API Features series.
+
+* Technologies that change more frequently are decoupled and specified in separate modules ("requirements classes" in OGC terminology). This enables, for example, the use/re-use of new encodings for spatial data or API descriptions.
+
+* Modularization is not just about features are resources, but about providing building blocks for fine-grained access to spatial data that can be used in Web APIs in general. In other words, a server supporting OGC API Features is not intended to implement just a standalone Features API. A corollary of this is that the same Web API may also implement other standards of the OGC API family that support additional resource types; for example, tile resources could provide access to the same features, but organized in a spatial partitioning system; or map resources could process the features and render them as as map images.
+
+Implementations of OGC API Features are intended to support two different approaches how clients can use the API.
+
+In the first approach, clients are implemented with knowledge about this standard and its resource types. The clients navigate the resources based on this knowledge and based on the responses provided by the API. The API definition may be used to determine details, e.g., on filter parameters, but this may not be necessary depending on the needs of the client. These are clients that are in general able to use multiple APIs as long as they implement OGC API Features.
+
+The other approach targets developers that are not familiar with the OGC API standards, but want to interact with spatial data provided by an API that happens to implement OGC API Features. In this case the developer will study and use the API definition - typically an OpenAPI document - to understand the API and implement the code to interact with the API. This assumes familiarity with the API definition language and the related tooling, but it should not be necessary to study the OGC API standards.
+
+=== Encodings
+
+This standard does not mandate any encoding or format for representing features or feature collections. In addition to HTML as the standard encoding for Web content, rules for commonly used encodings for spatial data on the web are provided (GeoJSON, GML).
+
+None of these encodings is mandatory and an implementation of the Core requirements class may implement none of them but implement another encoding instead.
+
+<<html5,Support for HTML is recommended>> as HTML is the core language of the World Wide Web. A server that supports HTML will support browsing the data with a web browser and will enable search engines to crawl and index the dataset.
+
+GeoJSON is a commonly used format that is simple to understand and well supported by tools and software libraries. Since most Web developers are comfortable with using a JSON-based format, this version of OGC API Features <<rfc7946,recommends supporting GeoJSON for encoding feature data>>, if the feature data can be represented in GeoJSON for the intended use.
+
+Some examples for cases that are out-of-scope of GeoJSON are:
+
+* When solids are used for geometries (e.g., in a 3D city model),
+
+* Geometries that include non-linear curve interpolations that cannot be simplified (e.g., use of arcs in authoritative geometries),
+
+* Geometries that have to be represented in a coordinate reference system that is not based on WGS 84 longitude/latitude (e.g., an authoritative national reference system), or
+
+* Features that have more than one geometric property.
+
+In addition to HTML and GeoJSON, a significant volume of feature data is available in XML-based formats, notably GML. GML supports more complex requirements than GeoJSON and does not have any of the limitations mentioned in the above bullets, but as a result GML is more complex to handle for both servers and clients. Conformance classes for GML are, therefore, included in this standard. It is expected that these conformance classes will typically be supported by servers where users are known to expect feature data in XML/GML.
+
+The recommendations for using HTML and GeoJSON reflect the importance of HTML and the current popularity of JSON-based data formats. As the practices in the Web community evolve, the recommendations will likely be updated in future versions of this standard to provide guidance on using other encodings.
+
+This part of the OGC API Features standards does not provide any guidance on other encodings. The supported encodings, or more precisely the media types of the supported encodings, can be determined from the API definition. The desired encoding is selected using HTTP content negotiation.
+
+For example, if the server supports https://tools.ietf.org/html/rfc8142[GeoJSON Text Sequences], an encoding that is based on JSON text sequences and GeoJSON to support streaming by making the data incrementally parseable, the media type `application/geo+json-seq` would be used.
+
+In addition, HTTP supports compression and therefore the standard HTTP mechanisms can be used to reduce the size of the messages between the server and the client.
+
+[[examples]]
+=== Examples
+
+This document uses a simple example throughout the document: The dataset contains buildings and the server provides access to them through a single feature collection ("buildings") and two encodings, GeoJSON and HTML.
+
+The buildings have a few (optional) properties: the polygon geometry of the building footprint, a name, the function of the building (residential, commercial or public use), the floor count and the timestamp of the last update of the building feature in the dataset.
+
+In addition to the examples included in the document, additional and more comprehensive examples are available at http://schemas.opengis.net/ogcapi/features/part1/1.0/examples.
+////

--- a/standard_implementation/sections/06-requirement_classes.adoc
+++ b/standard_implementation/sections/06-requirement_classes.adoc
@@ -1,0 +1,65 @@
+
+== Requirements Classes
+
+[NOTE]
+====
+Requirements are encoded using AsciiDoc markup for example blocks, prepended with an role attribute containing the type of the block (i.e. "`requirement`", "`recommendation`", or "`permission`").
+
+For more detailed information about encoding Requeriments, Recommendations, and Permissions visit: https://www.metanorma.com/author/topics/document-format/requirements-recommendations-permissions/
+====
+
+=== Requirement examples
+
+[requirement,type="class",label="Requeriment Label",obligation="requirement",subject="Web API",inherit="Dependency_1;Dependency_2;Dependency_3;Dependency_n"]
+====
+
+[requirement,type="general",label="Requeriment label 1"]
+======
+Description text
+======
+
+[requirement,type="general",label="Requeriment label 2"]
+======
+Description text
+======
+
+[requirement,type="general",label="Requeriment label 3"]
+======
+Description text
+======
+
+====
+
+[requirement,model=ogc,type="class",label="http://www.opengis.net/spec/waterml/2.0/req/xsd-xml-rules[*req/core*]",subject="Encoding of logical models",inherit="urn:iso:dis:iso:19156:clause:7.2.2;urn:iso:dis:iso:19156:clause:8;http://www.opengis.net/doc/IS/GML/3.2/clause/2.4;O&M Abstract model, OGC 10-004r3, clause D.3.4;http://www.opengis.net/spec/SWE/2.0/req/core/core-concepts-used",classification="priority:P0;domain:Hydrology,Groundwater;control-class:Technical",obligation="recommendation,requirement"]
+====
+I recommend this
+====
+
+
+=== Requirement examples
+
+[.requirement,label="requirement label"]
+====
+
+[.requirement]
+======
+Description text
+======
+
+====
+
+
+[.requirement,label="requirement label"]
+====
+
+[.requirement]
+======
+Description text
+======
+
+[.requirement]
+======
+Description text
+======
+
+====

--- a/standard_implementation/sections/07-media-types.adoc
+++ b/standard_implementation/sections/07-media-types.adoc
@@ -1,0 +1,4 @@
+
+== Media Types for any data encoding(s)
+
+A section describing the MIME-types to be used is mandatory for any standard involving data encodings. If no suitable MIME type exists in http://www.iana.org/assignments/media-types/index.html then this section may be used to define a new MIME type for registration with IANA.

--- a/standard_implementation/sections/aa-annexA.adoc
+++ b/standard_implementation/sections/aa-annexA.adoc
@@ -1,5 +1,5 @@
-[appendix]
-== Conformance Class Abstract Test Suite (Normative)
+[appendix,obligation="normative"]
+== Conformance Class Abstract Test Suite
 
 [NOTE]
 ====

--- a/standard_implementation/sections/aa-annexA.adoc
+++ b/standard_implementation/sections/aa-annexA.adoc
@@ -1,0 +1,32 @@
+[appendix]
+== Conformance Class Abstract Test Suite (Normative)
+
+[NOTE]
+====
+Ensure that there is a conformance class for each requirements class and a test for each requirement (identified by requirement name and number)
+====
+
+=== Conformance Class A
+
+[requeriment,type="verification"]
+====
+
+[requirement,type="general",label="Test id"]
+======
+conf/service/profile/basic-wps
+======
+
+[recommendation,type="general",label="Test purpose"]
+======
+Verify that the server implements the Basic WPS conformance class.
+======
+
+[requirement,type="general",label="Test method"]
+======
+Verify that the server implements the Synchronous WPS and/or the Asynchronous WPS conformance class. Verify that the requests and responses to a supported operation are syntactically correct. Verify that the service supports the Synchronous WPS Conformance class, the Asynchronous WPS Conformance class or both. Verify that all process offerings implement the native process model. Verify the following list of conformance tests:
+
+- Conformance test 1
+- Conformance test 2
+======
+
+====

--- a/standard_implementation/sections/ab-annexB.adoc
+++ b/standard_implementation/sections/ab-annexB.adoc
@@ -1,0 +1,4 @@
+[appendix,obligation="informative"]
+== Title
+
+<Place other Annex material in sequential annexes and leave final two annexes for the Revision History and Bibliography.>

--- a/standard_implementation/sections/ah-history.adoc
+++ b/standard_implementation/sections/ah-history.adoc
@@ -1,0 +1,10 @@
+
+[appendix]
+== Revision History
+
+[%unnumbered]
+[width="90%",options="header"]
+|===
+|Date |Release |Editor | Primary clauses modified |Description
+|2016-04-28 |0.1 |G. Editor |all |initial version
+|===

--- a/standard_implementation/sections/az-bibliography.adoc
+++ b/standard_implementation/sections/az-bibliography.adoc
@@ -1,0 +1,38 @@
+
+
+[bibliography]
+== Bibliography
+
+[NOTE]
+.Example Bibliography (Delete this note).
+====
+The TC has approved Springer LNCS as the official document citation type.
+
+Springer LNCS is widely used in technical and computer science journals and other publications
+
+For citations in the text please use square brackets and consecutive numbers: [1], [2], [3]
+
+Actual References:
+
+[n] Journal: Author Surname, A.: Title. Publication Title. Volume number, Issue number, Pages Used (Year Published)
+
+[n] Web: Author Surname, A.: Title, http://Website-Url
+====
+
+// Reference samples
+
+* [[[yaml,YAML]]], Ben-Kiki, O., Evans, C., Ingy döt Net: *YAML Ain’t Markup Language,* https://yaml.org/
+
+* [[[rfc3986,RFC3986]]], Berners-Lee, T., Fielding, R., Masinter, L.: *IETF RFC 3986 - Uniform Resource Identifier (URI): Generic Syntax,* http://tools.ietf.org/rfc/rfc3986.txt
+
+* [[[link_relations,Link Relation Types]]], IANA: *Link Relation Types,* https://www.iana.org/assignments/link-relations/link-relations.xml
+
+* [[[iso19142,ISO 19142]]], ISO: *ISO 19142:2010 - Geographic information - Web Feature Service* https://www.iso.org/standard/42136.html
+
+* [[[wfs20,WFS 2.0]]], OGC: *Web Feature Service 2.0,* http://docs.opengeospatial.org/is/09-025r2/09-025r2.html
+
+* [[[spatial_data_wbp,SDWBP]]], W3C/OGC: *Spatial Data on the Web Best Practices,* W3C Working Group Note 28 September 2017, https://www.w3.org/TR/sdw-bp/
+
+* [[[dwbp,WBP]]], W3C: *Data on the Web Best Practices,* W3C Recommendation 31 January 2017, https://www.w3.org/TR/dwbp/
+
+* [[[dcat,DCAT]]], W3C: *Data Catalog Vocabulary,* W3C Recommendation 16 January 2014, https://www.w3.org/TR/vocab-dcat/


### PR DESCRIPTION
From https://github.com/metanorma/mn-templates-ogc/issues/12

Hi @ronaldtse ,
- I created this template based on the existing `standard` template and  17-069r3 sample doc (http://docs.opengeospatial.org/is/17-069r3/17-069r3.html#_requirements_class_core)
- I noticed that the `standard` template I took guidance from contains both "images" and "figures"  folders. However, in the sample docs, we've been using just "images" folder for figure lodging.  So, I'm a little bit confused about which folder must be used at the end.

I'd really appreciate some feedback from you in this PR,
Thanks!