### PR TITLE
Add test-suite template

### DIFF
--- a/test-suite/document.adoc
+++ b/test-suite/document.adoc
@@ -1,0 +1,49 @@
+= OGC document title -- test-suite template
+:comment: ### Document type; mandatory. Visit: https://www.metanorma.com/author/ogc/authoring/ for permitted types
+:doctype: test-suite
+:comment: ### Version number; optional. Dot-delimited, preferably with this structure <version number>.<minor version number>.<patch version number>
+:edition: 1.0
+:comment: ### Language of the document; mandatory. Specified in two-letter code: "en" for English, "fr" for French
+:language: en
+:date: 2000-05-11
+:comment: ### Author one
+:fullname: Laura Diaz
+:comment: ### Author two
+:fullname_2: Bart van der Eijnden
+:comment: ### Author three
+:fullname_3: Barend Gehrels
+:comment: ### Role of the authors; mandatory
+:role: editor
+:comment: ### Document status/stage; mandatory. Visit: https://www.metanorma.com/author/ogc/authoring/ for permitted types
+:status: published
+:comment: ### Relevant committee; mandatory. The permitted types are: technical, planning, and strategic-member-advisory
+:committee: technical
+:comment: ### Internal reference number; mandatory
+:docnumber: 00-027
+:comment: ### External link referencing the document; optional. If not provided, a default value is created following this structure: "http://www.opengis.net/doc/{abbrevation of doctype}/{abbrev}/{version}", 
+:external-id:
+:comment: ### Semicolon-delimited list of the submitting organizations; mandatory
+:submitting-organizations: Geodan Holding bv, the Netherlands
+:comment: ### Name of the AsciiDoc file; mandatory
+:docfile: document.adoc
+:comment: ### Metanorma flavor; mandatory
+:mn-document-class: ogc
+:comment: ### Desired output formats; mandatory
+:mn-output-extensions: xml,html,doc,pdf,rxl
+:comment: ### Enable local relaton cache for quick inclusion of prefetched references; optional. For further information, visit: https://www.metanorma.com/author/ref/document-attributes/#caches, https://www.metanorma.com/author/topics/building/reference-lookup/#lookup-result-caching
+:local-cache-only:
+:comment: ### Encode all images in HTML output as inline data-URIs; optional
+:data-uri-image:
+
+
+include::sections/00-preface.adoc[]
+
+include::sections/01-overview.adoc[]
+
+include::sections/02-background.adoc[]
+
+include::sections/03-environment.adoc[]
+
+include::sections/04-description_of_the_test_procedures.adoc[]
+
+include::sections/aa-annexA.adoc[]

--- a/test-suite/sections/00-preface.adoc
+++ b/test-suite/sections/00-preface.adoc
@@ -1,0 +1,28 @@
+
+
+// Submitting organizations are inserted in the preamble using the `submitting-organizations` attribute
+
+
+[.preface]
+== Submission Contact Points
+
+All questions about the submission should be directed to:
+
+<Insert contact information: Name of contact, company, telephone number, fax number, email, website, etc.>
+
+
+[.preface]
+== Editors
+
+The following editors contributed to this document
+
+<Insert editors information: Name of contact, company, telephone number, fax number, email, website, etc.>
+
+
+[.preface]
+== Document Conventions
+
+<Insert document convensions.>
+
+
+// Insert any further preface sections using the "[.preface]" attribute

--- a/test-suite/sections/01-overview.adoc
+++ b/test-suite/sections/01-overview.adoc
@@ -1,0 +1,9 @@
+
+== Overview
+
+[NOTE]
+====
+Place relevant considerations, conditions, and restrictions about the usage 
+of the test procedures described in the document, as well as the purpose of the 
+conformance test and a general description of the content.
+====

--- a/test-suite/sections/02-background.adoc
+++ b/test-suite/sections/02-background.adoc
@@ -1,0 +1,8 @@
+
+[[background]]
+== Background
+
+<Provide a summary of Catalog Services.>
+
+
+

--- a/test-suite/sections/03-environment.adoc
+++ b/test-suite/sections/03-environment.adoc
@@ -1,0 +1,4 @@
+
+== Environment and setup of the Catalog Certification program
+
+<Provide a general description of how to configure the environment for the Catalog Certification Program.>

--- a/test-suite/sections/04-description_of_the_test_procedures.adoc
+++ b/test-suite/sections/04-description_of_the_test_procedures.adoc
@@ -1,0 +1,4 @@
+
+== Description of the test procedures
+
+<Provide descriptions of the testing procedures.>

--- a/test-suite/sections/aa-annexA.adoc
+++ b/test-suite/sections/aa-annexA.adoc
@@ -1,0 +1,11 @@
+
+[appendix,obligation=informative]
+[[appendixA]]
+== Title
+
+<Insert annex content here.>
+
+[NOTE]
+====
+Place annex material in sequential order and set `obligation` attribute as "normative" (default) or "informative" according to the case.
+====


### PR DESCRIPTION
*From https://github.com/metanorma/mn-templates-ogc/issues/12 and https://github.com/metanorma/mn-templates-ogc/issues/14*

Hi @ronaldtse ,

In this template I tried to apply what you stated in https://github.com/metanorma/mn-templates-ogc/issues/14, which I quote:

*Task is to copy documents from mn-samples-ogc, one for each document type, place them here and strip them of information so that they are "templates".*

Nonetheless, I feel this template resulted too short. I would appreciate some feedback in this case.

Thanks!