### PR TITLE
Add four OGC templates

### DIFF
--- a/other-primer/document.adoc
+++ b/other-primer/document.adoc
@@ -1,0 +1,67 @@
+= Primer of OGC (add title text)
+:comment: ### Document type; mandatory. Visit: https://www.metanorma.com/author/ogc/authoring/ for permitted types
+:doctype: best-practice
+:comment: ### Document subtype; mandatory for standard and best-practice doctype. Visit: https://www.metanorma.com/author/ogc/authoring/ for permitted values
+:docsubtype: general
+:comment: ### Document status/stage; mandatory. Visit: https://www.metanorma.com/author/ogc/authoring/ for permitted types
+:status: published
+:comment: ### Relevant committee; mandatory. The permitted types are: technical, planning, and strategic-member-advisory
+:committee: technical
+:comment: ### Internal reference number; mandatory
+:docnumber: 15-120r5
+:comment: ### Date on which the standard was updated; mandatory
+:received-date: 2018-03-20
+:comment: ### Date on which the standard was approved by the issuing authority; mandatory
+:issued-date: 2018-08-27
+:comment: ### Date on which the standard was published; mandatory
+:published-date: 2018-12-19
+:comment: ###  Year when the copyright for the document was issued; optional
+:copyright-year: 2018
+:comment: ### Version number; optional. Dot-delimited, preferably with this structure <version number>.<minor version number>
+:edition: 1.1
+:comment: ### External link referencing the document; optional. If not provided, a default value is created following this structure: "http://www.opengis.net/doc/{abbrevation of doctype}/{abbrev}/{version}"
+:external-id: http://www.opengis.net/doc/BP/cdb-core-primer/1.1
+:comment: ### Author one
+:fullname: John Doe
+:comment: ### Author two
+:fullname_2: Jane Doe
+:comment: ### Role of the authors; optional. Supply only if correspoding author is an editor
+:role_2: editor
+:comment: ### Comma delimited keywords; mandatory
+:keywords: ogcdoc, OGC document, CDB, Common Data Base, simulation, synthetic environment, virtual, primer, data store
+:comment: ### Semicolon-delimited list of the submitting organizations; mandatory
+:submitting-organizations: CAE Inc.;Carl Reed, OGC Individual Member;Envitia, Ltd;Glen Johnson, OGC Individual Member;KaDSci, LLC;Laval University;Open Site Plan;University of Calgary;UK Met Office
+:comment: ### Metanorma flavor; mandatory
+:mn-document-class: ogc
+:comment: ### Desired output formats; mandatory
+:mn-output-extensions: xml,html,doc,pdf,rxl
+:comment: ### Name of the AsciiDoc file; mandatory
+:docfile: document.adoc
+:comment: ### Directory name used as prefix for the location of image files; optional
+:imagesdir: images
+:comment: ### Enable local relaton cache for quick inclusion of prefetched references; optional. For further information, visit: https://www.metanorma.com/author/ref/document-attributes/#caches, https://www.metanorma.com/author/topics/building/reference-lookup/#lookup-result-caching
+:local-cache-only:
+:comment: ### Encode all images in HTML output as inline data-URIs; optional
+:data-uri-image:
+
+// Clauses
+include::sections/00-preface.adoc[]
+include::sections/01-introduction.adoc[]
+include::sections/02-norm-refs.adoc[]
+include::sections/03-terms_and_definitions.adoc[]
+
+// Add clause files as needed
+include::sections/04-other-clauses.adoc[]
+
+////
+Annexes
+Add annex files as needed
+////
+include::sections/aa-annexA.adoc[]
+
+////
+Revision History should be the last annex before the Bibliography
+Bibliography should be the last annex
+////
+include::sections/ah-revision-history.adoc[]
+include::sections/az-references.adoc[]

--- a/other-primer/sections/00-preface.adoc
+++ b/other-primer/sections/00-preface.adoc
@@ -1,0 +1,36 @@
+
+////
+Preface sections must include [.preface] attribute
+in order to get them placed in the preface area (and not in the main content).
+
+Keywords specified in document preamble should display in this area
+after the abstract as well as the submitting organizations
+////
+
+
+[abstract]
+== Abstract
+
+// Insert abstract content
+Abstract content.
+
+
+[.preface]
+== Other sections
+
+// Insert any other sections as needed
+Other section content.
+
+
+[.preface]
+== Submitters
+All questions regarding this submission should be directed to the editor or the submitters:
+
+[%unnumbered]
+|===
+|Name |Affiliation
+
+|Carl Reed |Carl Reed & Associates
+|David Graham |CAE Inc.
+|===
+

--- a/other-primer/sections/01-introduction.adoc
+++ b/other-primer/sections/01-introduction.adoc
@@ -1,0 +1,6 @@
+
+== Introduction
+
+// Insert introduction content adding subsections as needed
+
+Introduction content.

--- a/other-primer/sections/02-norm-refs.adoc
+++ b/other-primer/sections/02-norm-refs.adoc
@@ -1,6 +1,6 @@
 
 [bibliography]
-== Normative and Informative References
+== Normative references
 
 The following are the key normative references for this Primer
 

--- a/other-primer/sections/02-norm-refs.adoc
+++ b/other-primer/sections/02-norm-refs.adoc
@@ -1,0 +1,28 @@
+
+[bibliography]
+== Normative and Informative References
+
+The following are the key normative references for this Primer
+
+// Typical reference entries (without auto-fetch)
+// Reference content will display as written
+* [[[ogc-cdb-core-vol1,OGC CDB Core Standard Volume 1]]] Volume 1: OGC CDB Core Standard: Model and Physical Data Store Structure.
+
+* [[[ogc-cdb-core-vol11,OGC CDB Core Standard Volume 11]]] Volume 11: OGC CDB Core Standard Conceptual Model
+
+The following informative references are applicable for this Primer.
+
+* [[[ieee-std-1516,IEEE Std 1516]]] HLA [IEEE Std 1516]: 1516-2010 - IEEE Standard for Modeling and Simulation (M&S) High Level Architecture (HLA) - Framework and Rules
+
+* [[[ieee-std-1278,IEEE Std 1278]]] DIS [IEEE Std 1278]: 1278.1-2012 - IEEE Standard for Distributed Interactive Simulation--Application Protocols
+
+// Automatic reference fetching entries (auto-fetch)
+// To verify the reference lookup syntax for all the supported flavors,
+// visit: https://www.metanorma.com/author/topics/building/reference-lookup/#reference-lookup-syntax
+* [[[rfc2616,RFC 2616]]], Fielding, R., Gettys, J., Mogul, J., Frystyk, H., Masinter, L., Leach, P., Berners-Lee, T.: IETF RFC 2616, *HTTP/1.1*, 1999 http://tools.ietf.org/rfc/rfc2616.txt
+
+* [[[rfc2818,RFC 2818]]], Rescorla, E.: IETF RFC 2818, *HTTP Over TLS*, 2000 http://tools.ietf.org/rfc/rfc2818.txt
+
+* [[[rfc3339,RFC 3339]]], Klyne, G., Newman, C.: IETF RFC 3339, *Date and Time on the Internet: Timestamps*, 2002 http://tools.ietf.org/rfc/rfc3339.txt
+
+* [[[rfc8288,RFC 8288]]], Nottingham, M.: IETF RFC 8288, *Web Linking*, 2017 http://tools.ietf.org/rfc/rfc8288.txt

--- a/other-primer/sections/03-terms_and_definitions.adoc
+++ b/other-primer/sections/03-terms_and_definitions.adoc
@@ -1,5 +1,5 @@
 
-== Terms and Definitions
+== Terms and definitions
 
 // You can insert paragraphs as needed in this area
 

--- a/other-primer/sections/03-terms_and_definitions.adoc
+++ b/other-primer/sections/03-terms_and_definitions.adoc
@@ -1,0 +1,30 @@
+
+== Terms and Definitions
+
+// You can insert paragraphs as needed in this area
+
+
+// Insert terms and definitions content
+// For example
+=== example term
+
+term used for exemplary purposes
+
+[.source]
+<<rfc2616>>
+
+NOTE: An example note.
+
+[example]
+Here's an example of an example term.
+
+
+=== Abbreviations
+// Insert abbreviated terms content
+// For example
+*CGF*:: Computer Generated Forced
+*DB*:: Database
+*DIS*:: Distributed Interactive Simulation [IEEE std 1278]
+*DBGF*:: Database Generation Facility [IEEE std 1516]
+*IG*:: Image Generator
+

--- a/other-primer/sections/04-other-clauses.adoc
+++ b/other-primer/sections/04-other-clauses.adoc
@@ -1,0 +1,12 @@
+
+[[clause-reference]]
+== Other clauses
+
+//Insert clause content here
+
+Clause content.
+
+[NOTE]
+====
+Add any other clauses as needed
+====

--- a/other-primer/sections/aa-annexA.adoc
+++ b/other-primer/sections/aa-annexA.adoc
@@ -1,0 +1,15 @@
+
+// If obligation is not specified, "normative" is taken by default
+[appendix,obligation="normative"]
+[[annex-reference]]
+== Annex Title
+
+// Insert annex content here
+
+Annex content.
+
+[NOTE]
+====
+Place annex material in sequential order and set `obligation` attribute as "normative" (default) or "informative" according to the case.
+====
+

--- a/other-primer/sections/ah-revision-history.adoc
+++ b/other-primer/sections/ah-revision-history.adoc
@@ -1,0 +1,11 @@
+
+[[annex-revision-history]]
+[appendix,obligation="informative"]
+== Revision history
+
+[%unnumbered]
+[width="90%",options="header"]
+|===
+|Date |Release |Author | Paragraph |Description
+|2016-04-28 |1.0 |C. Reed |Various |Edits for publication
+|===

--- a/other-primer/sections/az-references.adoc
+++ b/other-primer/sections/az-references.adoc
@@ -1,0 +1,32 @@
+
+[[annex-references]]
+[appendix,obligation="informative"]
+[bibliography]
+== References
+
+// Typical reference entry (without auto-fetch)
+// Reference content will display as written
+* [[[Simonis2018,Simonis, I.]]], Standardized Big Data Processing in Hybrid Clouds. In: Proceedings of the 4th International Conference on Geographical Information Systems Theory, Applications and Management - Volume 1: GISTAM, pp. 205–210. SciTePress (2018).
+
+// Automatic reference fetching (auto-fetch)
+// To verify the reference lookup syntax for all the supported flavors,
+// visit: https://www.metanorma.com/author/topics/building/reference-lookup/#reference-lookup-syntax
+* [[[ogc14-083r2,OGC 14-083r2]]], OGC: OGC 14-083r2: Moving Features Encoding Part I: XML Core, 2015
+
+// Disabling auto-fetch
+// You can disable auto-fetch by wrapping the identifier into nofetch() -- `nofetch({identifier})`
+// (To disable auto-fetch in all references at once, set `no-isobib` attribute at the beginning of the document)
+* [[[ogc14-084r2,(nofetch)OGC 14-084r2]]], OGC: OGC 14-084r2: Moving Features Encoding Extension: Simple Comma Separated Values 
+
+// Reference entry with user-supplied label (non-auto-fetch)
+* [[[ogc11-165r2,(CF-netCDF3)]]], OGC: OGC 11-165r2: CF-netCDF3 Data Model Extension standard, 2012
+
+// Reference entry with user-supplied label (with auto-fetch enabled)
+* [[[ogc10-092r3,(NetCDF)OGC 10-092r3]]], OGC: OGC 10-092r3: NetCDF Binary Encoding Extension Standard: netCDF Classic and 64-bit Offset Format, 2011
+
+// Numeric reference entry (with no auto-fetch)
+// To use numeric reference system, place a number as identifer
+// Any number can be used. All references will be re-sorted and auto-incremented during compilation
+* [[[netcdf,1]]], Lawrence Livermore National Laboratory: NetCDF CF Metadata Conventions – http://cfconventions.org/[http://cfconventions.org/]
+
+* [[[acdd,1]]], ESIP: Attribute Convention for Data Discovery (ACDD) – http://wiki.esipfed.org/index.php/

--- a/policy/document.adoc
+++ b/policy/document.adoc
@@ -1,0 +1,54 @@
+= Policy for OGC (add title text)
+:comment: ### Document type; mandatory. Visit: https://www.metanorma.com/author/ogc/authoring/ for permitted types
+:doctype: policy
+:comment: ### Document status/stage; mandatory. Visit: https://www.metanorma.com/author/ogc/authoring/ for permitted types
+:status: published
+:comment: ### Relevant committee; mandatory. The permitted types are: technical, planning, and strategic-member-advisory
+:committee: Technical Committee
+:comment: ### Internal reference number; mandatory
+:docnumber: 05-020r27
+:comment: ### Date on which the standard was updated; mandatory
+:received-date: 2019-03-28
+:comment: ### Date on which the standard was approved by the issuing authority; mandatory
+:issued-date: 2019-05-29
+:comment: ### Date on which the standard was published; mandatory
+:published-date: 2019-06-03
+:copyright-year: 2019
+:comment: ### Version number; optional. Dot-delimited, preferably with this structure <version number>.<minor version number>
+:edition: 27.0
+:comment: ### External link referencing the document; optional. If not provided, a default value is created following this structure: "http://www.opengis.net/doc/{abbrevation of doctype}/{abbrev}/{version}"
+:external-id: http://www.opengis.net/doc/pol/tcpnp/27.0
+:comment: ### Author one
+:fullname: John Doe
+:comment: ### Author two
+:fullname_2: Jane Doe
+:comment: ### Role of the authors; optional. Supply only if correspoding author is an editor
+:role_2: editor
+:comment: ### Metanorma flavor; mandatory
+:mn-document-class: ogc
+:comment: ### Directory name used as prefix for the location of image files; optional
+:imagesdir: images
+:comment: ### Name of the AsciiDoc file; mandatory
+:docfile: document.adoc
+:comment: ### Desired output formats; mandatory
+:mn-output-extensions: xml,html,doc,pdf,rxl
+:comment: ### Enable local relaton cache for quick inclusion of prefetched references; optional. For further information, visit: https://www.metanorma.com/author/ref/document-attributes/#caches, https://www.metanorma.com/author/topics/building/reference-lookup/#lookup-result-caching
+:local-cache-only:
+:comment: ### Encode all images in HTML output as inline data-URIs; optional
+:data-uri-image:
+
+
+// Clauses
+include::sections/00-preface.adoc[]
+include::sections/01-introduction.adoc[]
+include::sections/02-terms-and-definitions.adoc[]
+
+// Add clause files as needed
+include::sections/03-other-clauses.adoc[]
+
+////
+Annexes
+Add annex files as needed
+////
+include::sections/aa-annexA.adoc[]
+

--- a/policy/sections/00-preface.adoc
+++ b/policy/sections/00-preface.adoc
@@ -1,0 +1,21 @@
+
+////
+Preface sections must include [.preface] attribute
+in order to get them placed in the preface area (and not in the main content).
+
+Keywords specified in document preamble will display in this area
+after the abstract
+////
+
+[abstract]
+== Abstract
+
+// Insert abstract content
+Abstract content.
+
+
+[.preface]
+== Other sections
+
+// Insert any other sections as needed
+Other section content.

--- a/policy/sections/01-introduction.adoc
+++ b/policy/sections/01-introduction.adoc
@@ -1,0 +1,6 @@
+
+== Introduction
+
+// Insert introduction content adding subsections as needed
+
+Introduction content.

--- a/policy/sections/02-terms-and-definitions.adoc
+++ b/policy/sections/02-terms-and-definitions.adoc
@@ -1,0 +1,20 @@
+
+== Terms and definitions
+
+// Insert terms and definitions content
+
+// For example
+
+OGC Communication: A communication by any means, including posting on the WWW Site (http://www.opengeospatial.org), electronic mail, facsimile transmission, or by regular post. The primary forms of communication will be either via email or using the OGC Members Only Portal. Any member desiring delivery by other than electronic means (WWW site or electronic mail) must state so in written form to OGC staff.
+
+OGC standard: A document containing an OGC consensus computing technology dependent standard for application programming interfaces and related standards based on the Abstract Specification or domain-specific extensions to the Abstract Specification provided by domain experts. OGC standards generally have evidence of implementation.
+
+OGC Member, or Member: Any member in good standing.
+
+OGC Member Portal: A members’ only accessible component of the OGC web site. The Portal provides a location for storing and accessing all in progress OGC TC and PC documents, all WG agendas, working documents, and presentations, and to perform project management functions, such as tasks, tracking actions, and calendars.
+
+OGC Standards Program: Provides an industry consensus process to plan, review and officially adopt OGC Standards for interfaces and protocols that enable interoperable geoprocessing services, data, and applications. The OGC bodies involved in the Standard Program are the Technical Committee, Planning Committee, and Strategic Member Advisory Committee.
+
+Profile: [ISO 19106:2004, Type 1 Profile] A profile is a pure subset of an existing standard including restrictions on or deletions of conformance clauses related to the subsetting. An example of a profile is the GML Simple Feature Profile.
+
+Profile with Extension: A profile with extension is a set of one or more conformance clauses from a base standard that includes at least one new conformance clause (extension). An example is OpenGIS(R) Web Map Services - Profile for EO Products.

--- a/policy/sections/03-other-clauses.adoc
+++ b/policy/sections/03-other-clauses.adoc
@@ -1,0 +1,12 @@
+
+[[clause-reference]]
+== Other clauses
+
+//Insert clause content here
+
+Clause content.
+
+[NOTE]
+====
+Add any other clauses as needed
+====

--- a/policy/sections/aa-annexA.adoc
+++ b/policy/sections/aa-annexA.adoc
@@ -1,0 +1,14 @@
+
+// If obligation is not specified, "normative" is taken by default
+[appendix,obligation="normative"]
+[[annex-reference]]
+== Annex Title
+
+// Insert annex content here
+
+Annex content.
+
+[NOTE]
+====
+Place annex material in sequential order and set `obligation` attribute as "normative" (default) or "informative" according to the case.
+====

--- a/reference-model/document.adoc
+++ b/reference-model/document.adoc
@@ -1,0 +1,57 @@
+= Reference Model for OGC (add title text)
+:comment: ### Document type; mandatory. Visit: https://www.metanorma.com/author/ogc/authoring/ for permitted types
+:doctype: reference-model
+:comment: ### Document status/stage; mandatory. Visit: https://www.metanorma.com/author/ogc/authoring/ for permitted types
+:status: published
+:comment: ### Relevant committee; mandatory. The permitted types are: technical, planning, and strategic-member-advisory
+:committee: technical
+:comment: ### Internal reference number; mandatory
+:docnumber: 08-062r7
+:comment: ### Version number; optional. Dot-delimited, preferably with this structure <version number>.<minor version number>
+:edition: 2.1
+:comment: ### Date on which the document was last updated; optional
+:revdate: 2011-12-19
+:comment: ### Date on which the standard was updated; mandatory
+:received-date: 2011-12-19
+:comment: ### Date on which the standard was approved by the issuing authority; mandatory
+:issued-date: 2011-12-19
+:comment: ### Date on which the standard was published; mandatory
+:published-date: 2011-12-19
+:comment: ###  Year when the copyright for the document was issued; optional
+:copyright-year: 2011
+:comment: ### External link referencing the document; optional. If not provided, a default value is created following this structure: "http://www.opengis.net/doc/{abbrevation of doctype}/{abbrev}/{version}"
+:external-id: http://www.opengis.net/doc/orm/2.1
+:comment: ### Author one
+:fullname: John Doe
+:comment: ### Author two
+:fullname_2: Jane Doe
+:comment: ### Role of the authors; optional. Supply only if correspoding author is an editor
+:role_2: editor
+:comment: ### Comma delimited keywords; mandatory
+:keywords: keyword_1, keyword_2, keyword_3, etc
+:comment: ### Name of the AsciiDoc file; mandatory
+:docfile: document.adoc
+:comment: ### Metanorma flavor; mandatory
+:mn-document-class: ogc
+:comment: ### Desired output formats; mandatory
+:mn-output-extensions: xml,html,doc,pdf,rxl
+:comment: ### Directory name used as prefix for the location of image files; optional
+:imagesdir: images
+:comment: ### Enable local relaton cache for quick inclusion of prefetched references; optional. For further information, visit: https://www.metanorma.com/author/ref/document-attributes/#caches, https://www.metanorma.com/author/topics/building/reference-lookup/#lookup-result-caching
+:local-cache-only:
+:comment: ### Encode all images in HTML output as inline data-URIs; optional
+:data-uri-image:
+
+// Clauses
+include::sections/00-preface.adoc[]
+
+// Add clause files as needed
+include::sections/01-other-clauses.adoc[]
+
+////
+Annexes
+Add annex files as needed
+Revision History should be the last annex
+////
+include::sections/aa-annexA.adoc[]
+include::sections/ab-revision_history.adoc[]

--- a/reference-model/sections/00-preface.adoc
+++ b/reference-model/sections/00-preface.adoc
@@ -1,0 +1,16 @@
+
+////
+Preface sections must include [.preface] attribute
+in order to get them placed in the preface area (and not in the main content).
+
+Keywords specified in document preamble should display in this area
+////
+
+
+[.preface]
+== Introduction
+
+// Insert introduction content. (You can add subsections as needed.)
+
+Introduction content.
+

--- a/reference-model/sections/01-other-clauses.adoc
+++ b/reference-model/sections/01-other-clauses.adoc
@@ -1,0 +1,12 @@
+
+[[clause-reference]]
+== Other clauses
+
+//Insert clause content here
+
+Clause content.
+
+[NOTE]
+====
+Add any other clauses as needed
+====

--- a/reference-model/sections/aa-annexA.adoc
+++ b/reference-model/sections/aa-annexA.adoc
@@ -1,0 +1,14 @@
+
+// If obligation is not specified, "normative" is taken by default
+[appendix,obligation="normative"]
+[[annex-reference]]
+== Annex Title
+
+// Insert annex content here
+
+Annex content.
+
+[NOTE]
+====
+Place annex material in sequential order and set `obligation` attribute as "normative" (default) or "informative" according to the case.
+====

--- a/reference-model/sections/ab-revision_history.adoc
+++ b/reference-model/sections/ab-revision_history.adoc
@@ -1,0 +1,11 @@
+
+[appendix,obligation=informative]
+== Revision history
+
+[%unnumbered]
+[width="90%",options="header"]
+|===
+^.^| Date ^.^| Release ^.^| Author ^.^| Description
+|2016-04-28 |1.0 |C. Reed |Edits for publication
+|===
+

--- a/user-guide/document.adoc
+++ b/user-guide/document.adoc
@@ -1,0 +1,48 @@
+= User guide for OGC (add title text)
+:comment: ### Document type; mandatory. Visit: https://www.metanorma.com/author/ogc/authoring/ for permitted types
+:doctype: user-guide
+:comment: ### Document status/stage; mandatory. Visit: https://www.metanorma.com/author/ogc/authoring/ for permitted types
+:status: published
+:comment: ### Relevant committee; mandatory. The permitted types are: technical, planning, and strategic-member-advisory
+:committee: technical
+:comment: ### Internal reference number; mandatory
+:docnumber: 16-080
+:comment: ### Date on which the standard was updated; mandatory
+:received-date: 2017-06-29
+:comment: ### Date on which the standard was approved by the issuing authority; mandatory
+:issued-date: 2017-06-29
+:comment: ### Date on which the standard was published; mandatory
+:published-date: 2017-01-23
+:comment: ###  Year when the copyright for the document was issued; optional
+:copyright-year: 2017
+:comment: ### External link referencing the document; optional. If not provided, a default value is created following this structure: "http://www.opengis.net/doc/{abbrevation of doctype}/{abbrev}/{version}"
+:external-id: http://www.opengis.net/doc/PER/t12-A063
+:comment: ### Author one
+:fullname: John Doe
+:comment: ### Author two
+:fullname_2: Jane Doe
+:comment: ### Role of the authors; optional. Supply only if correspoding author is an editor
+:role_2: editor
+:comment: ### Comma delimited keywords; mandatory
+:keywords: keyword_1, keyword_2, keyword_3, etc.
+:comment: ### Semicolon-delimited list of the submitting organizations; mandatory
+:submitting-organizations: organization_1; organization_2; organization_3; etc.
+:comment: ### Name of the AsciiDoc file; mandatory
+:docfile: document.adoc
+:comment: ### Metanorma flavor; mandatory
+:mn-document-class: ogc
+:comment: ### Desired output formats; mandatory
+:mn-output-extensions: xml,html,doc,pdf,rxl
+:comment: ### Directory name used as prefix for the location of image files; optional
+:imagesdir: images
+:comment: ### Enable local relaton cache for quick inclusion of prefetched references; optional. For further information, visit: https://www.metanorma.com/author/ref/document-attributes/#caches, https://www.metanorma.com/author/topics/building/reference-lookup/#lookup-result-caching
+:local-cache-only:
+:comment: ### Encode all images in HTML output as inline data-URIs; optional
+:data-uri-image:
+
+
+// Clauses
+include::sections/00-preface.adoc[]
+include::sections/01-normative-references.adoc[]
+include::sections/02-other-clauses.adoc[]
+

--- a/user-guide/sections/00-preface.adoc
+++ b/user-guide/sections/00-preface.adoc
@@ -1,0 +1,22 @@
+
+////
+Preface sections must include [.preface] attribute
+in order to get them placed in the preface area (and not in the main content).
+
+Keywords specified in document preamble will display in this area
+after the abstract
+////
+
+[.preface]
+== Introduction
+
+// Insert introduction content, adding subsections as needed
+
+Introduction content.
+
+
+[.preface]
+== Other sections
+
+// Insert any other sections as needed
+Other section content.

--- a/user-guide/sections/01-normative-references.adoc
+++ b/user-guide/sections/01-normative-references.adoc
@@ -1,0 +1,26 @@
+
+[bibliography]
+== References
+
+// Typical reference entries (without auto-fetch)
+// Reference content will display as written
+* [[[openapi,Open API Initiative]]], Open API Initiative: *OpenAPI Specification 3.0.2*, 2018 https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md
+
+* [[[gmlsf,GMLSF]]], van den Brink, L., Portele, C., Vretanos, P.: OGC 10-100r3, *Geography Markup Language (GML) Simple Features Profile*, 2012 http://portal.opengeospatial.org/files/?artifact_id=42729
+
+* [[[html5,HTML5]]], W3C: *HTML5*, W3C Recommendation, 2019 http://www.w3.org/TR/html5/
+
+* [[[schema,Schema.org]]], *Schema.org:* http://schema.org/docs/schemas.html
+
+// Automatic reference fetching entries (auto-fetch)
+// To verify the reference lookup syntax for all the supported flavors,
+// visit: https://www.metanorma.com/author/topics/building/reference-lookup/#reference-lookup-syntax
+* [[[rfc2616,RFC 2616]]], Fielding, R., Gettys, J., Mogul, J., Frystyk, H., Masinter, L., Leach, P., Berners-Lee, T.: IETF RFC 2616, *HTTP/1.1*, 1999 http://tools.ietf.org/rfc/rfc2616.txt
+
+* [[[rfc2818,RFC 2818]]], Rescorla, E.: IETF RFC 2818, *HTTP Over TLS*, 2000 http://tools.ietf.org/rfc/rfc2818.txt
+
+* [[[rfc3339,RFC 3339]]], Klyne, G., Newman, C.: IETF RFC 3339, *Date and Time on the Internet: Timestamps*, 2002 http://tools.ietf.org/rfc/rfc3339.txt
+
+* [[[rfc8288,RFC 8288]]], Nottingham, M.: IETF RFC 8288, *Web Linking*, 2017 http://tools.ietf.org/rfc/rfc8288.txt
+
+* [[[rfc7946,RFC 7946]]], Butler, H., Daly, M., Doyle, A., Gillies, S., Hagen, S., Schaub, T.: IETF RFC 7946, *The GeoJSON Format*, 2016 https://tools.ietf.org/rfc/rfc7946.txt

--- a/user-guide/sections/02-other-clauses.adoc
+++ b/user-guide/sections/02-other-clauses.adoc
@@ -1,0 +1,11 @@
+[[clause-reference]]
+== Other clauses
+
+//Insert clause content here
+
+Clause content.
+
+[NOTE]
+====
+Add any other clauses as needed
+====


### PR DESCRIPTION
*From https://github.com/metanorma/mn-templates-ogc/issues/12*

Added: `primer`, `policy`, `reference-model`, and `user-guide` templates.

I believe these are the last ones regarding OGC flavor.

Thanks!